### PR TITLE
Adding custom setter for Attachments

### DIFF
--- a/src/Models/Communication.php
+++ b/src/Models/Communication.php
@@ -36,6 +36,7 @@ class Communication extends Model
             $communicationEmail->HtmlBody = $email->getHtml();
             $communicationEmail->TextBody = $email->getText();
             $communicationEmail->Subject = $email->getSubject();
+            $communicationEmail->Attachments = $email->getAttachments();
 
             $communication->Emails->append($communicationEmail);
         }

--- a/src/Models/CommunicationEmail.php
+++ b/src/Models/CommunicationEmail.php
@@ -66,11 +66,6 @@ class CommunicationEmail extends Model
         throw new ModelConsistencyValidationException();
     }
 
-    public function setAttachments($attachments)
-    {
-        $this->setModelValue("Attachments", json_encode($attachments));
-    }
-
     protected function getConsistencyValidationErrors()
     {
         $validationErrors = parent::getConsistencyValidationErrors();
@@ -112,9 +107,8 @@ class CommunicationEmail extends Model
         $simpleEmail->setSender($this->SenderEmail, $this->SenderName);
         $simpleEmail->setHtml($this->HtmlBody);
 
-        $attachmentsArray = json_decode($this->Attachments);
-        if (!empty($attachmentsArray)) {
-            foreach ($attachmentsArray as $attachment) {
+        if (!empty($this->Attachments)) {
+            foreach ($this->Attachments as $attachment) {
                 $simpleEmail->addAttachment($attachment->path, $attachment->name);
             }
         }
@@ -124,7 +118,7 @@ class CommunicationEmail extends Model
 
     public function addAttachment($path, $newName = "")
     {
-        $attachments = json_decode($this->Attachments, true);
+        $attachments = $this->Attachments;
 
         if ($newName == "") {
             $newName = basename($path);

--- a/src/Models/CommunicationEmail.php
+++ b/src/Models/CommunicationEmail.php
@@ -66,6 +66,11 @@ class CommunicationEmail extends Model
         throw new ModelConsistencyValidationException();
     }
 
+    public function setAttachments($attachments)
+    {
+        $this->setModelValue("Attachments", json_encode($attachments));
+    }
+
     protected function getConsistencyValidationErrors()
     {
         $validationErrors = parent::getConsistencyValidationErrors();
@@ -131,6 +136,6 @@ class CommunicationEmail extends Model
 
         $attachments[] = $file;
 
-        $this->Attachments = json_encode($attachments);
+        $this->Attachments = $attachments;
     }
 }

--- a/tests/unit/Models/CommunicationEmailTest.php
+++ b/tests/unit/Models/CommunicationEmailTest.php
@@ -30,7 +30,6 @@ class CommunicationEmailTest extends CommunicationTestCase
         $this->assertEquals($communicationEmail->SenderEmail,$email->getSender()->email, "RecipientEmail don't match");
         $this->assertEquals($communicationEmail->TextBody,$email->getText(), "TextBody don't match");
         $this->assertEquals($communicationEmail->HtmlBody,$email->getHtml(), "HtmlBody don't match");
-        $attachments = json_decode($communicationEmail->Attachments);
-        $this->assertEquals($attachments, $email->getAttachments(), "Attachments don't match");
+        $this->assertEquals($communicationEmail->Attachments, $email->getAttachments(), "Attachments don't match");
     }
 }


### PR DESCRIPTION
The following Pull Request adds a custom setter for Attachments on the CommunicationEmail class. This will ensure that the data is encoded correctly before being persisted to the relevant data storage of the model.