### PR TITLE
mysql 5.6 support - optional non-native json columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.2.3
+
+* Fixed: Mysql 5.6 support by optionally not using native json columns
+
 ### 1.2.2
 
 * Fixed:    DateSent in attempt log not being set correctly.

--- a/src/Models/CommunicationItem.php
+++ b/src/Models/CommunicationItem.php
@@ -4,6 +4,7 @@ namespace Rhubarb\Scaffolds\Communications\Models;
 
 use Rhubarb\Crown\DateTime\RhubarbDateTime;
 use Rhubarb\Crown\Sendables\Email\Email;
+use Rhubarb\Scaffolds\Communications\Settings\CommunicationsSettings;
 use Rhubarb\Stem\Filters\AndGroup;
 use Rhubarb\Stem\Filters\Equals;
 use Rhubarb\Stem\Models\Model;
@@ -55,7 +56,7 @@ class CommunicationItem extends Model
             new StringColumn("SendableClassName", 150),
             new StringColumn("Recipient", 200),
             new LongStringColumn("Text"),
-            new MySqlJsonColumn("Data", "", true, false),
+            new MySqlJsonColumn("Data", "", true, CommunicationsSettings::singleton()->nativeJSONColumns),
             new DateTimeColumn("DateCreated"),
             new DateTimeColumn("DateSent"),
             new StringColumn("FailureReason", 500),

--- a/src/Models/CommunicationItem.php
+++ b/src/Models/CommunicationItem.php
@@ -55,7 +55,7 @@ class CommunicationItem extends Model
             new StringColumn("SendableClassName", 150),
             new StringColumn("Recipient", 200),
             new LongStringColumn("Text"),
-            new MySqlJsonColumn("Data", "", true),
+            new MySqlJsonColumn("Data", "", true, false),
             new DateTimeColumn("DateCreated"),
             new DateTimeColumn("DateSent"),
             new StringColumn("FailureReason", 500),

--- a/src/Settings/CommunicationsSettings.php
+++ b/src/Settings/CommunicationsSettings.php
@@ -17,4 +17,6 @@ class CommunicationsSettings extends ApplicationSettings
     public static $showSendAllCommunicationsButton = false;
 
     public static $defaultDateTimeFormat = CommunicationDecorator::DATE_FORMAT;
+
+    public $nativeJSONColumns = true;
 }


### PR DESCRIPTION
use a setting to control the use of native json columns for 5.6 compatability